### PR TITLE
Fixed menus.py

### DIFF
--- a/src/cogs/menus.py
+++ b/src/cogs/menus.py
@@ -14,7 +14,7 @@ class Menus(commands.Cog, command_attrs=dict(hidden=True), name="menus"):
     @commands.is_owner()
     async def reactionroles(self, ctx):
         """Send the reaction roles embeds!"""
-        for embed, view in await Listener.reactionroles():
+        for embed, view in await Listener.reactionroles(ctx):
             await ctx.send(embed=embed, view=view)
 
     @commands.command()


### PR DESCRIPTION
This PR fixes error when trying to do ,reactionroles

the error was ` Traceback (most recent call last):
  File "C:\Users\user\PycharmProjects\bot\venv\lib\site-packages\discord\ext\commands\core.py", line 181, in wrapped
    ret = await coro(*args, **kwargs)
  File "C:\Users\user\PycharmProjects\bot\src\cogs\menus.py", line 17, in reactionroles
    for embed, view in await Listener.reactionroles():
TypeError: reactionroles() missing 1 required positional argument: 'ctx' `

This has been tested with my instance of the bot and works without issue.